### PR TITLE
Exceptions KeyboardInterrupt and EOFError suppressed

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,12 @@
 from hangman.__main__ import main
+import sys
 
-if __name__ == '__main__':
-    main()
+try:
+    if __name__ == '__main__':
+        main()
+
+except KeyboardInterrupt:
+    sys.exit(0)
+
+except EOFError:
+    sys.exit(0)


### PR DESCRIPTION
Exceptions `KeyboardInterrupt` and `EOFError` raised when hitting `Ctrl + C` and `Ctrl + D` respectively have been suppressed, terminating the game neatly.